### PR TITLE
Add default ctrl-c listener for automatic copy to clipboard

### DIFF
--- a/src/common/components/buttons.tsx
+++ b/src/common/components/buttons.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { DocumentDuplicateIcon, CheckIcon } from "@heroicons/react/24/solid";
 import clsx from "clsx";
 
@@ -15,10 +15,12 @@ export function CopyToClipboard({
   getText,
   bigger = false,
   disabled = false,
+  enableHotkeys = false,
 }: {
   getText: () => string;
   bigger?: boolean;
   disabled?: boolean;
+  enableHotkeys?: boolean;
 }) {
   const [isCopied, setIsCopied] = useState(false);
 
@@ -31,6 +33,26 @@ export function CopyToClipboard({
       console.error("Failed to copy text: ", err);
     }
   }, [getText, setIsCopied]);
+
+  useEffect(() => {
+    if (disabled || !enableHotkeys) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const isCmdC = (e.ctrlKey || e.metaKey) && e.key === "c";
+
+      if (isCmdC) {
+        // Only intercept if no text is manually selected.
+        const hasSelection = window.getSelection()?.toString().length ?? 0 > 0;
+        if (!hasSelection) {
+          e.preventDefault();
+          copy();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [copy, disabled, enableHotkeys]);
 
   return (
     <button

--- a/src/common/components/copyTextEntry.tsx
+++ b/src/common/components/copyTextEntry.tsx
@@ -26,9 +26,11 @@ const usePasteFromClipboard = () => {
 export const CopyTextEntry = ({
   onCopy,
   onPaste,
+  enableHotkeys = true,
 }: {
   onCopy: (text: string) => string;
   onPaste: (text: string) => string;
+  enableHotkeys?: boolean;
 }) => {
   const {
     onClick: copyFromClipboard,
@@ -75,7 +77,7 @@ export const CopyTextEntry = ({
         </button>
 
         <div className="absolute right-2 bottom-2 flex flex-col items-end gap-1 bg-transparent">
-          <CopyToClipboard getText={getText} />
+          <CopyToClipboard enableHotkeys={enableHotkeys} getText={getText} />
         </div>
       </div>
 
@@ -90,9 +92,11 @@ export const CopyTextEntry = ({
 export const CopyTextEntryDirect = ({
   onCopy,
   onPaste,
+  enableHotkeys = true,
 }: {
   onCopy: (text: string) => string;
   onPaste: (text: string) => string;
+  enableHotkeys?: boolean;
 }) => {
   const {
     onClick: copyFromClipboard,
@@ -137,7 +141,11 @@ export const CopyTextEntryDirect = ({
             </button>
           </div>
 
-          <CopyToClipboard getText={getText} bigger />
+          <CopyToClipboard
+            enableHotkeys={enableHotkeys}
+            getText={getText}
+            bigger
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
In case a user enters Ctrl+c while not typing in anything, then automatically copy to clipboard the value of copy-to-clipboard component.
